### PR TITLE
Update Games List - February 9, 2025.json

### DIFF
--- a/Games List.json
+++ b/Games List.json
@@ -166,7 +166,7 @@
         {
           "titlename": "Carcassonne",
           "titleimage": "Carcassone",
-          "titleicon": "https://xbox360media.ign.com/xbox360/image/object/850/850005/XBL_Carcassonne.jpg?width=250&crop=1%3A1%2Csmart&auto=webp",
+          "titleicon": "https://cdn2.steamgriddb.com/grid/16c10d788ab45577d1b8dbfd8cd963f3.jpg",
           "titlebackground": "https://assets.nintendo.com/image/upload/f_auto/q_auto/dpr_1.5/ncom/en_US/games/switch/c/carcassonne-switch/hero",
           "type": 1
         },
@@ -313,7 +313,7 @@
         {
           "titlename": "Minecraft",
           "titleimage": "minecraft_bedrock",
-          "titleicon": "https://cdn.icon-icons.com/icons2/2699/PNG/512/minecraft_logo_icon_168974.png",
+          "titleicon": "https://cdn2.steamgriddb.com/grid/9713fc04477ccf52eb7e03f626985ec2.png",
           "titlebackground": "https://i.blogs.es/0eb073/minecraft-generacionxbox-1/1366_2000.jpeg",
           "type": 1
         },
@@ -455,7 +455,7 @@
         {
           "titlename": "Halo Infinite",
           "titleimage": "halo_infinite",
-          "titleicon": "https://www.tierragamer.com/wp-content/uploads/2020/07/halo-portada.jpg",
+          "titleicon": "https://cdn2.steamgriddb.com/grid/ad3613baccebc39f8d17615c108b34f2.png",
           "titlebackground": "https://www.windowscentral.com/sites/wpcentral.com/files/styles/large/public/field/image/2020/07/halo-infinite-chief-hero-1.jpg",
           "type": 1
         },
@@ -581,7 +581,7 @@
         {
           "titlename": "Microsoft Edge",
           "titleimage": "Microsoft_Edge",
-          "titleicon": "https://upload.wikimedia.org/wikipedia/commons/9/98/Microsoft_Edge_logo_%282019%29.svg",
+          "titleicon": "https://cdn2.steamgriddb.com/grid/a3103498620c4e279cdbed83fb95b728.png",
           "titlebackground": "https://www.lifewire.com/thmb/NSE8G8rmX6Yxf3sxckcXhW7puVw=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/001-what-is-microsoft-edge-4151828-b50ba4a178d54bb287c62419dd80c6d7.jpg",
           "type": 3
         },
@@ -651,7 +651,7 @@
         {
           "titlename": "PDP Control Hub",
           "titleimage": "PDP_Control_Hub",
-          "titleicon": "https://store-images.s-microsoft.com/image/apps.20790.14536315885801770.076b8775-9c74-4ce6-a4db-0a04d323096c.6ec01100-1fb8-4238-9c7e-052a05a5e6a6",
+          "titleicon": "https://m.media-amazon.com/images/I/61Eg5ytuoBL._AC_UF1000,1000_QL80_.jpg",
           "titlebackground": "https://store-images.s-microsoft.com/image/apps.21661.14536315885801770.076b8775-9c74-4ce6-a4db-0a04d323096c.4361a4a1-ec55-4b07-98f8-c9640954808d",
           "type": 3
         },
@@ -665,7 +665,7 @@
         {
           "titlename": "Halo 5: Guardians",
           "titleimage": "halo_5",
-          "titleicon": "https://i.blogs.es/2081f1/halo5_keyart_vert_final/240_240.jpg",
+          "titleicon": "https://cdn2.steamgriddb.com/grid/b3db884cef9edfad43681cc20d3d884d.png",
           "titlebackground": "https://www.10wallpaper.com/wallpaper/1366x768/1509/Halo_5_Guardian_Game_HD_Widescreen_Wallpaper_1366x768.jpg",
           "type": 1
         },
@@ -770,7 +770,7 @@
         {
           "titlename": "Call Of Duty: Modern Warfare 2",
           "titleimage": "cod_mw2",
-          "titleicon": "https://ellocodesebas.files.wordpress.com/2010/07/cod-mw2.jpg",
+          "titleicon": "https://cdn2.steamgriddb.com/grid/0cee28d807acc0fa495ac258fcb2109e.png",
           "titlebackground": "https://image.api.playstation.com/vulcan/img/rnd/202010/1520/9cpUjddAWgBvJTY4MvmqyyE1.png",
           "type": 1
         },
@@ -924,7 +924,7 @@
         {
           "titlename": "Gears of War 3",
           "titleimage": "Gears3.png",
-          "titleicon": "http://lmk.tdgalea.co.uk/share/Photography/Gaming/Box Art/Gears of War/Gears3.png",
+          "titleicon": "https://cdn2.steamgriddb.com/grid/91deaef164356d6d62478eceb9afaa6b.png",
           "titlebackground": "https://store-images.s-microsoft.com/image/apps.41576.68607194681373551.b4c09a44-be36-42d6-96c5-4a33b566becd.bbbcda5d-ebd5-4c6b-9d13-67171a49d833",
           "type": 1
         },
@@ -952,7 +952,7 @@
         {
           "titlename": "Gears 5",
           "titleimage": "Gears5.png",
-          "titleicon": "http://lmk.tdgalea.co.uk/share/Photography/Gaming/Box Art/Gears of War/Gears5.png",
+          "titleicon": "https://cdn2.steamgriddb.com/grid/dbbfa43eef839542428b19391b87eb74.png",
           "titlebackground": "https://store-images.s-microsoft.com/image/apps.21372.65494054591008504.3eb95796-405c-4def-901b-3b53a1c9e001.7ce477d1-54a6-4286-b3e1-f3145baf4ba2",
           "type": 1
         },
@@ -980,7 +980,7 @@
         {
           "titlename": "Modern Warfare 2",
           "titleimage": "cod_mw2_360",
-          "titleicon": "https://assets-prd.ignimgs.com/2022/09/24/codforcerecon-1664045338431.jpg",
+          "titleicon": "https://cdn2.steamgriddb.com/grid/0cee28d807acc0fa495ac258fcb2109e.png",
           "titlebackground": "https://www.kawerna.pl/wp-content/uploads/2020/04/remastered-cod2.jpg",
           "type": 1
         },
@@ -1015,7 +1015,7 @@
         {
           "titlename": "Kinect Sports: Season Two",
           "titleimage": "ks_season2",
-          "titleicon": "https://m.media-amazon.com/images/I/71ZleHj2UKL.jpg",
+          "titleicon": "https://image.torob.com/base/images/9v/55/9v55RkftvWPhSpul.jpg",
           "titlebackground": "https://www.mobygames.com/images/promo/original/1478557560-1581798436.jpg",
           "type": 1
         },
@@ -1134,7 +1134,7 @@
         {
           "titlename": "Hydro Thunder",
           "titleimage": "Hydro_Thunder",
-          "titleicon": "https://www.mobygames.com/images/covers/l/303536-hydro-thunder-hurricane-xbox-360-front-cover.png",
+          "titleicon": "https://assets-prd.ignimgs.com/2022/06/18/hydrothunder-1655580743040.jpg",
           "titlebackground": "https://download-ssl.xbox.com/content/images/66acd000-77fe-1000-9115-d8025841096a/1033/screenlg3.jpg",
           "type": 1
         },
@@ -1239,7 +1239,7 @@
         {
           "titlename": "Blue Dragon",
           "titleimage": "blue_dragon",
-          "titleicon": "https://cdn2.steamgriddb.com/icon/96ecbfadac55a39b8909822f91399f00/32/64x64.png",
+          "titleicon": "https://rhythmverse.co/assets/album_art/e/eternity-19191.png",
           "titlebackground": "https://store-images.s-microsoft.com/image/apps.55545.65457035095819016.56f55216-1bb9-40aa-8796-068cf3075fc1.4c2daefb-fbf6-4b90-b392-bf8ecc39a92e",
           "type": 1
         },
@@ -1575,7 +1575,7 @@
         {
           "titlename": "Skate 3",
           "titleimage": "skate3",
-          "titleicon": "https://store-images.s-microsoft.com/image/apps.18720.68005754082254855.39795a60-73cf-4461-87d9-7f112c30c43c.46888afa-996b-4016-b5b4-c2e0b78171e2?q=90&w=177&h=265",
+          "titleicon": "https://cdn2.steamgriddb.com/grid/200c1f6ed0eb22bf43a5a7de97f185ac.jpg",
           "titlebackground": "https://store-images.s-microsoft.com/image/apps.10583.68005754082254855.39795a60-73cf-4461-87d9-7f112c30c43c.a86b405a-b519-4836-9b3c-9fed5c0c8b41?q=90&w=320&h=180",
           "type": 1
         },
@@ -1589,7 +1589,7 @@
         {
           "titlename": "Minecraft Legends",
           "titleimage": "Minecraft_Legends",
-          "titleicon": "https://tinfoil.media/ti/01007C6012CC8000/0/0/",
+          "titleicon": "https://cdn2.steamgriddb.com/grid/0576bce3ca971dfd913c582a14945d96.png",
           "titlebackground": "https://assets.nintendo.com/image/upload/c_fill,w_1200/q_auto:best/f_auto/dpr_2.0/ncom/software/switch/70010000033696/be89eb9c1c6a57cf58e8d14b03d26b4c42d988e02c082fd0fe368417c43b959e",
           "type": 1
         },
@@ -1743,7 +1743,7 @@
         {
           "titlename": "XDefiant Open Session",
           "titleimage": "xdef_os",
-          "titleicon": "https://upload.anarchyisland.gg/r/XDefiant%20Icon.jpg?compress=false",
+          "titleicon": "https://cdn2.steamgriddb.com/grid/d153407a197a930109d7f1e2a5331a8d.png",
           "titlebackground": "https://upload.anarchyisland.gg/r/XDefiant%20Background.jpg?compress=false",
           "type": 1
         },


### PR DESCRIPTION
±Updated Minecraft
±Updated Halo Infinite
±Updated Microsoft Edge
±Updated Minecraft Legends
±Updated Carcassonne
±Updated PDP Control Hub
±Updated Halo 5: Guardians
±Updated Call of Duty: Modern Warfare 2 (2009)
±Updated Gears of War 3
±Updated Gears 5
±Updated Kinect Sports: Season Two
±Updated Hydro Thunder
±Updated Blue Dragon
±Updated Skate 3
±Updated XDefiant Open Session