### PR TITLE
Updated Game List - June 25, 2026 | Part 2

### DIFF
--- a/Games List.json
+++ b/Games List.json
@@ -1657,7 +1657,7 @@
           "type": 1
         },
         {
-          "titlename": "DEAD OR ALIVE 6 Last Round Core Fighters",
+          "titlename": "DEAD OR ALIVE 6 Last Round: Core Fighters",
           "titleimage": "doa6_LR_CF",
           "titleicon": "https://cdn2.steamgriddb.com/grid/311d49a40545086c9c4f02782e5e84da.png",
           "titlebackground": "https://teamninja-studio.com/doa6/lastround/assets/img/common/doa6LR_site-top_poster.jpg",


### PR DESCRIPTION
±Fixed DEAD OR ALIVE 6 Last Round: Core Fighters